### PR TITLE
feat: add Claude Code Bridge for WhatsApp self-message integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,21 @@
+# WhatsApp Claude Bridge Configuration
+# Copy this file to .env and fill in your values
+
+# Your WhatsApp phone number (without + or spaces)
+# Example: 5521999999999 for Brazil +55 21 99999-9999
+YOUR_PHONE=
+
+# Allowed tools for Claude Code CLI
+# Controls which tools Claude can use when responding to WhatsApp messages
+# Examples:
+#   "*" - Allow all tools (default)
+#   "Read Write Edit" - Allow only file operations
+#   "Bash(ls:*) Bash(pwd) Read" - Allow only ls commands, pwd, and Read
+#   "mcp__whatsapp mcp__google-workspace Read" - Allow specific MCP servers and Read
+#   "" - Allow no tools (Claude will only be able to respond with text)
+ALLOWED_TOOLS="*"
+
+# Note: MCP servers (like Google Workspace, WhatsApp) are configured separately
+# in their own Docker containers with their own .env files.
+# Claude Code CLI will automatically discover and connect to them via
+# the Claude Extensions configuration in ~/Library/Application Support/Claude/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,41 @@ claude_desktop_config.json
 whatsapp.log
 .DS_Store
 .claude/commands
+
+# Environment configuration
+.env
+.env.local
+
+# Service configuration files
+com.*.claude-bridge.plist
+*.plist
+
+# Virtual environment
+.venv/
+venv/
+
+# Logs
+*.log
+logs/
+Library/Logs/ClaudeBridge/
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.pyc
+.Python
+
+# macOS
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# WhatsApp Bridge store
+whatsapp-bridge/store/

--- a/claude-bridge-service.py
+++ b/claude-bridge-service.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""
+Claude Bridge Background Service
+Runs as a macOS launchd daemon to provide WhatsApp <-> Claude Code integration
+"""
+import asyncio
+import subprocess
+import json
+import time
+import logging
+import sys
+import signal
+import os
+from typing import Optional
+from pathlib import Path
+
+try:
+    import aiohttp
+except ImportError:
+    print("Error: aiohttp not installed. Run: pip3 install aiohttp")
+    sys.exit(1)
+
+class ClaudeBridgeService:
+    def __init__(self):
+        self.bridge_url = "http://localhost:8080"
+        self.your_phone = os.getenv('YOUR_PHONE', '')
+        self.allowed_tools = os.getenv('ALLOWED_TOOLS', '*')
+        self.last_query_time = 0
+        self.min_query_interval = 10  # Rate limiting
+        self.running = True
+        
+        # Setup logging
+        self.setup_logging()
+        
+        # Validate environment variables
+        if not self.your_phone:
+            self.logger.error("YOUR_PHONE environment variable not set")
+            sys.exit(1)
+            
+        self.logger.info(f"Allowed tools configured: {self.allowed_tools}")
+            
+        # Setup signal handlers for graceful shutdown
+        signal.signal(signal.SIGTERM, self.signal_handler)
+        signal.signal(signal.SIGINT, self.signal_handler)
+        
+    def setup_logging(self):
+        """Setup logging to file and stdout"""
+        log_dir = Path.home() / "Library" / "Logs" / "ClaudeBridge"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_file = log_dir / "claude-bridge.log"
+        
+        # Create formatter
+        formatter = logging.Formatter(
+            '%(asctime)s - %(levelname)s - %(message)s'
+        )
+        
+        # Setup logger
+        self.logger = logging.getLogger('ClaudeBridge')
+        self.logger.setLevel(logging.INFO)
+        
+        # File handler
+        file_handler = logging.FileHandler(log_file)
+        file_handler.setFormatter(formatter)
+        self.logger.addHandler(file_handler)
+        
+        # Console handler (for debugging)
+        console_handler = logging.StreamHandler()
+        console_handler.setFormatter(formatter)
+        self.logger.addHandler(console_handler)
+        
+    def signal_handler(self, signum, frame):
+        """Handle shutdown signals gracefully"""
+        self.logger.info(f"Received signal {signum}, shutting down gracefully...")
+        self.running = False
+        
+    async def wait_for_bridge(self, max_retries=30):
+        """Wait for WhatsApp bridge to be ready"""
+        for attempt in range(max_retries):
+            try:
+                async with aiohttp.ClientSession() as session:
+                    async with session.get(f"{self.bridge_url}/api/claude/pending", timeout=5) as resp:
+                        if resp.status == 200:
+                            self.logger.info("✅ WhatsApp bridge is ready")
+                            return True
+            except Exception as e:
+                if attempt == 0:
+                    self.logger.info("⏳ Waiting for WhatsApp bridge to start...")
+                elif attempt % 5 == 0:  # Log every 5 attempts
+                    self.logger.info(f"Still waiting for bridge... (attempt {attempt+1}/{max_retries})")
+                
+            await asyncio.sleep(2)
+            
+        self.logger.error("❌ WhatsApp bridge failed to start within timeout")
+        return False
+        
+    async def poll_for_messages(self):
+        """Continuously poll for self-messages"""
+        self.logger.info("🚀 Claude Bridge Service started")
+        
+        # Wait for bridge to be ready
+        if not await self.wait_for_bridge():
+            return
+            
+        consecutive_errors = 0
+        max_consecutive_errors = 10
+        
+        while self.running:
+            try:
+                async with aiohttp.ClientSession() as session:
+                    async with session.get(f"{self.bridge_url}/api/claude/pending", timeout=10) as resp:
+                        if resp.status == 200:
+                            data = await resp.json()
+                            if data.get('has_pending'):
+                                self.logger.info(f"📱 Processing message: {data['message'][:50]}...")
+                                await self.process_claude_request(data['message'], data['timestamp'])
+                            
+                        consecutive_errors = 0  # Reset error counter
+                        
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                consecutive_errors += 1
+                self.logger.error(f"Polling error ({consecutive_errors}/{max_consecutive_errors}): {e}")
+                
+                if consecutive_errors >= max_consecutive_errors:
+                    self.logger.error("Too many consecutive errors, shutting down")
+                    break
+                    
+                # Exponential backoff
+                wait_time = min(30, 2 ** consecutive_errors)
+                await asyncio.sleep(wait_time)
+                continue
+                
+            await asyncio.sleep(2)  # Normal polling interval
+            
+        self.logger.info("🛑 Claude Bridge Service stopped")
+    
+    async def process_claude_request(self, message: str, timestamp: str):
+        """Process a Claude request using host's Claude Code CLI"""
+        
+        # Rate limiting
+        current_time = time.time()
+        if current_time - self.last_query_time < self.min_query_interval:
+            await self.send_response("⏰ Please wait 10 seconds between queries", timestamp)
+            return
+            
+        self.last_query_time = current_time
+        
+        try:
+            # Clean and limit input
+            clean_message = message.strip()[:1000]
+            
+            self.logger.info(f"🤖 Calling Claude Code: {clean_message[:100]}...")
+            
+            # Use shell script to execute Claude in proper terminal context
+            # This ensures MCP servers and authentication work properly
+            # The shell script sources ~/.zshrc which provides all necessary
+            # environment including MCP configurations
+            script_path = Path(__file__).parent / 'claude-executor.sh'
+            
+            if not script_path.exists():
+                self.logger.error(f"Shell script not found at {script_path}")
+                await self.send_response("❌ Claude executor script not found", timestamp)
+                return
+                
+            # Pass ALLOWED_TOOLS to the subprocess
+            env = os.environ.copy()
+            env['ALLOWED_TOOLS'] = self.allowed_tools
+            
+            result = await asyncio.create_subprocess_exec(
+                '/bin/bash', str(script_path), clean_message,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=env
+            )
+            
+            stdout, stderr = await asyncio.wait_for(
+                result.communicate(), 
+                timeout=300.0  # 5 minutes timeout
+            )
+            
+            if result.returncode == 0:
+                response = stdout.decode('utf-8').strip()
+                # Log the response content (truncated if too long)
+                response_preview = response[:200] + "..." if len(response) > 200 else response
+                self.logger.info(f"✅ Claude responded ({len(response)} chars): {response_preview}")
+                await self.send_chunked_response(f"🤖 Claude:\n{response}", timestamp)
+            else:
+                error_msg = stderr.decode('utf-8').strip()
+                self.logger.error(f"❌ Claude Code error: {error_msg}")
+                await self.send_response(f"❌ Claude Error: {error_msg[:300]}", timestamp)
+                
+        except asyncio.TimeoutError:
+            self.logger.warning("⏰ Claude Code timeout")
+            await self.send_response("⏰ Claude Code timed out (set limit)", timestamp)
+        except FileNotFoundError:
+            self.logger.error("❌ Claude Code CLI not found")
+            await self.send_response("❌ Claude Code CLI not found. Please install it first.", timestamp)
+        except Exception as e:
+            self.logger.error(f"❌ Unexpected error: {e}")
+            await self.send_response(f"❌ Failed to call Claude: {str(e)[:200]}", timestamp)
+    
+    async def send_chunked_response(self, response: str, timestamp: str):
+        """Split long responses into WhatsApp-friendly chunks"""
+        max_length = 1500  # WhatsApp message limit
+        
+        if len(response) <= max_length:
+            await self.send_response(response, timestamp)
+            return
+            
+        # Split into chunks
+        chunks = [response[i:i+max_length] for i in range(0, len(response), max_length)]
+        
+        self.logger.info(f"📤 Sending response in {len(chunks)} chunks")
+        
+        for i, chunk in enumerate(chunks):
+            prefix = f"[{i+1}/{len(chunks)}] " if len(chunks) > 1 else ""
+            chunk_preview = chunk[:100] + "..." if len(chunk) > 100 else chunk
+            self.logger.info(f"📤 Sending chunk {i+1}/{len(chunks)}: {chunk_preview}")
+            await self.send_response(f"{prefix}{chunk}", timestamp)
+            if i < len(chunks) - 1:  # Don't sleep after last chunk
+                await asyncio.sleep(1.5)  # Delay between chunks
+    
+    async def send_response(self, response: str, timestamp: str):
+        """Send response back through container bridge"""
+        try:
+            async with aiohttp.ClientSession() as session:
+                payload = {
+                    "recipient": self.your_phone,
+                    "message": response,
+                    "timestamp": timestamp
+                }
+                async with session.post(f"{self.bridge_url}/api/claude/respond", json=payload, timeout=15) as resp:
+                    if resp.status == 200:
+                        # Log a preview of what was sent
+                        message_preview = response[:100] + "..." if len(response) > 100 else response
+                        self.logger.info(f"✅ Response sent: {message_preview}")
+                    else:
+                        self.logger.error(f"❌ Failed to send response: HTTP {resp.status}")
+        except Exception as e:
+            self.logger.error(f"❌ Error sending response: {e}")
+
+async def main():
+    service = ClaudeBridgeService()
+    try:
+        await service.poll_for_messages()
+    except KeyboardInterrupt:
+        service.logger.info("Interrupted by user")
+    except Exception as e:
+        service.logger.error(f"Fatal error: {e}")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    # Check if Claude CLI is available
+    claude_path = '/opt/homebrew/bin/claude'
+    try:
+        if not Path(claude_path).exists():
+            print(f"❌ Error: Claude CLI not found at {claude_path}")
+            print("Please install Claude Code CLI first: https://docs.anthropic.com/en/docs/claude-code")
+            sys.exit(1)
+        else:
+            print(f"✅ Claude CLI found at: {claude_path}")
+    except Exception as e:
+        print(f"❌ Error checking Claude CLI: {e}")
+        sys.exit(1)
+    
+    # Run the service
+    asyncio.run(main())

--- a/claude-executor.sh
+++ b/claude-executor.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# This script executes Claude CLI in the same context as a terminal session
+# to ensure MCP servers and authentication work properly
+
+# Source the user's shell profile to get all environment variables
+if [ -f ~/.zshrc ]; then
+    source ~/.zshrc
+elif [ -f ~/.bash_profile ]; then
+    source ~/.bash_profile
+elif [ -f ~/.bashrc ]; then
+    source ~/.bashrc
+fi
+
+# Get the message from the first argument
+MESSAGE="$1"
+
+# Get allowed tools from environment variable (default to "*" if not set)
+ALLOWED_TOOLS="${ALLOWED_TOOLS:-*}"
+
+# Change to home directory (or you can change to a specific project directory)
+cd "$HOME"
+
+# Execute Claude with the message and allowed tools configuration
+if [ "$ALLOWED_TOOLS" = "" ]; then
+    # If ALLOWED_TOOLS is explicitly empty, don't pass the flag at all
+    /opt/homebrew/bin/claude -p "$MESSAGE"
+else
+    # Pass the allowed tools configuration
+    /opt/homebrew/bin/claude -p "$MESSAGE" --allowedTools $ALLOWED_TOOLS
+fi

--- a/manage-claude-bridge.sh
+++ b/manage-claude-bridge.sh
@@ -1,0 +1,509 @@
+#!/bin/bash
+
+# Claude Bridge Service Manager
+# Manages the macOS background service for WhatsApp <-> Claude integration
+
+SERVICE_NAME="com.$(whoami).claude-bridge"
+PLIST_FILE="$HOME/Library/LaunchAgents/$SERVICE_NAME.plist"
+CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SERVICE_SCRIPT="$CURRENT_DIR/claude-bridge-service.py"
+LOG_DIR="$HOME/Library/Logs/ClaudeBridge"
+VENV_DIR="$CURRENT_DIR/.venv"
+VENV_PYTHON="$VENV_DIR/bin/python"
+ENV_FILE="$CURRENT_DIR/.env"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+print_status() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+print_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+load_env_file() {
+    if [ -f "$ENV_FILE" ]; then
+        print_status "Loading environment variables from .env file..."
+        # Export variables from .env file, ignoring comments and empty lines
+        while IFS='=' read -r key value; do
+            # Skip comments and empty lines
+            if [[ ! "$key" =~ ^# ]] && [[ -n "$key" ]]; then
+                # Remove quotes from value if present
+                value="${value%\"}"
+                value="${value#\"}"
+                export "$key=$value"
+            fi
+        done < "$ENV_FILE"
+        print_success "Environment variables loaded from .env"
+    else
+        print_warning ".env file not found at $ENV_FILE"
+        print_warning "Please create it from .env.example:"
+        print_warning "  cp $CURRENT_DIR/.env.example $ENV_FILE"
+        print_warning "  nano $ENV_FILE"
+        return 1
+    fi
+}
+
+check_prerequisites() {
+    print_status "Checking prerequisites..."
+    
+    # Check if Claude CLI is installed
+    if ! command -v claude &> /dev/null; then
+        print_error "Claude CLI not found. Please install it first:"
+        print_error "https://docs.anthropic.com/en/docs/claude-code"
+        return 1
+    else
+        CLAUDE_PATH=$(which claude)
+        print_success "Claude CLI found at: $CLAUDE_PATH"
+    fi
+    
+    # Check if Python 3 is available
+    if ! command -v python3 &> /dev/null; then
+        print_error "Python 3 not found. Please install Python 3."
+        return 1
+    else
+        PYTHON_PATH=$(which python3)
+        PYTHON_VERSION=$(python3 --version)
+        print_success "Python found at: $PYTHON_PATH ($PYTHON_VERSION)"
+    fi
+    
+    # Check if service script exists
+    if [ ! -f "$SERVICE_SCRIPT" ]; then
+        print_error "Service script not found at: $SERVICE_SCRIPT"
+        return 1
+    else
+        print_success "Service script found: $SERVICE_SCRIPT"
+    fi
+    
+    # Check if uv is available
+    if ! command -v uv &> /dev/null; then
+        print_error "uv not found. Please install it first:"
+        print_error "curl -LsSf https://astral.sh/uv/install.sh | sh"
+        return 1
+    else
+        UV_PATH=$(which uv)
+        print_success "uv found at: $UV_PATH"
+    fi
+    
+    print_success "All prerequisites met"
+    return 0
+}
+
+setup_virtual_environment() {
+    print_status "Setting up Python virtual environment..."
+    
+    # Remove existing venv if it exists
+    if [ -d "$VENV_DIR" ]; then
+        print_status "Removing existing virtual environment..."
+        rm -rf "$VENV_DIR"
+    fi
+    
+    # Create new virtual environment with uv
+    print_status "Creating virtual environment with uv..."
+    if uv venv "$VENV_DIR" --python python3; then
+        print_success "Virtual environment created at: $VENV_DIR"
+    else
+        print_error "Failed to create virtual environment"
+        return 1
+    fi
+    
+    # Install dependencies
+    print_status "Installing dependencies with uv..."
+    if uv pip install --python "$VENV_PYTHON" aiohttp; then
+        print_success "Dependencies installed successfully"
+    else
+        print_error "Failed to install dependencies"
+        return 1
+    fi
+    
+    # Verify installation
+    if "$VENV_PYTHON" -c "import aiohttp; print(f'aiohttp {aiohttp.__version__} installed')" 2>/dev/null; then
+        print_success "Dependencies verified successfully"
+    else
+        print_error "Dependency verification failed"
+        return 1
+    fi
+    
+    return 0
+}
+
+install_service() {
+    print_status "Installing Claude Bridge service..."
+    
+    # Load environment variables from .env file
+    if ! load_env_file; then
+        return 1
+    fi
+    
+    # Check required environment variables
+    if [ -z "$YOUR_PHONE" ]; then
+        print_error "YOUR_PHONE variable is not set in .env file"
+        print_error "Please edit $ENV_FILE and set YOUR_PHONE=<your_phone_number>"
+        return 1
+    fi
+    
+    print_success "Environment variables validated"
+    
+    if ! check_prerequisites; then
+        return 1
+    fi
+    
+    # Setup virtual environment
+    if ! setup_virtual_environment; then
+        return 1
+    fi
+    
+    # Stop service if it's already running
+    if launchctl list | grep -q "$SERVICE_NAME"; then
+        print_status "Stopping existing service..."
+        launchctl unload "$PLIST_FILE" 2>/dev/null
+    fi
+    
+    # Create log directory
+    print_status "Creating log directory: $LOG_DIR"
+    if mkdir -p "$LOG_DIR"; then
+        print_success "Log directory created"
+    else
+        print_error "Failed to create log directory"
+        return 1
+    fi
+    
+    # Make service script executable
+    print_status "Making service script executable..."
+    if chmod +x "$SERVICE_SCRIPT"; then
+        print_success "Service script is executable"
+    else
+        print_error "Failed to make service script executable"
+        return 1
+    fi
+    
+    # Create LaunchAgents directory if it doesn't exist
+    print_status "Creating LaunchAgents directory..."
+    if mkdir -p "$HOME/Library/LaunchAgents"; then
+        print_success "LaunchAgents directory ready"
+    else
+        print_error "Failed to create LaunchAgents directory"
+        return 1
+    fi
+    
+    # Generate plist with correct virtual environment paths
+    print_status "Generating service configuration..."
+    cat > "$PLIST_FILE" << EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- Service identification -->
+    <key>Label</key>
+    <string>$SERVICE_NAME</string>
+    
+    <!-- Program to run -->
+    <key>Program</key>
+    <string>$VENV_PYTHON</string>
+    
+    <!-- Program arguments -->
+    <key>ProgramArguments</key>
+    <array>
+        <string>$VENV_PYTHON</string>
+        <string>$SERVICE_SCRIPT</string>
+    </array>
+    
+    <!-- Working directory -->
+    <key>WorkingDirectory</key>
+    <string>$HOME</string>
+    
+    <!-- Environment variables -->
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$HOME/.local/bin</string>
+        <key>HOME</key>
+        <string>$HOME</string>
+        <key>USER</key>
+        <string>$(whoami)</string>
+        <key>VIRTUAL_ENV</key>
+        <string>$VENV_DIR</string>
+        <key>YOUR_PHONE</key>
+        <string>${YOUR_PHONE}</string>
+        <key>ALLOWED_TOOLS</key>
+        <string>${ALLOWED_TOOLS:-*}</string>
+        <key>CLAUDE_CODE_ENTRYPOINT</key>
+        <string>sdk-ts</string>
+        <key>CLAUDECODE</key>
+        <string>1</string>
+        <key>CLAUDE_EXTENSIONS_DIR</key>
+        <string>$HOME/.claude-bridge/Claude Extensions</string>
+        <key>CLAUDE_EXTENSIONS_SETTINGS_DIR</key>
+        <string>$HOME/.claude-bridge/Claude Extensions Settings</string>
+    </dict>
+    
+    <!-- Auto-start and restart behavior -->
+    <key>RunAtLoad</key>
+    <true/>
+    
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+        <key>Crashed</key>
+        <true/>
+    </dict>
+    
+    <!-- Restart after crash with delay -->
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+    
+    <!-- Logging -->
+    <key>StandardOutPath</key>
+    <string>$LOG_DIR/stdout.log</string>
+    
+    <key>StandardErrorPath</key>
+    <string>$LOG_DIR/stderr.log</string>
+    
+    <!-- Process limits -->
+    <key>ProcessType</key>
+    <string>Background</string>
+    
+    <!-- Only run when user is logged in -->
+    <key>LimitLoadToSessionType</key>
+    <array>
+        <string>Aqua</string>
+    </array>
+    
+    <!-- Resource limits -->
+    <key>SoftResourceLimits</key>
+    <dict>
+        <key>NumberOfFiles</key>
+        <integer>1024</integer>
+    </dict>
+    
+    <!-- Don't run if disabled -->
+    <key>Disabled</key>
+    <false/>
+    
+</dict>
+</plist>
+EOF
+
+    if [ $? -eq 0 ]; then
+        print_success "Service configuration generated at: $PLIST_FILE"
+    else
+        print_error "Failed to generate service configuration"
+        return 1
+    fi
+    
+    # Verify the plist file is valid
+    print_status "Verifying service configuration..."
+    if plutil -lint "$PLIST_FILE" > /dev/null 2>&1; then
+        print_success "Service configuration is valid"
+    else
+        print_error "Service configuration is invalid. Check the plist file."
+        return 1
+    fi
+    
+    # Copy Claude Extensions and settings for MCP server access
+    print_status "Copying Claude Extensions for MCP server access..."
+    CLAUDE_EXTENSIONS_DIR="$HOME/Library/Application Support/Claude/Claude Extensions"
+    CLAUDE_EXTENSIONS_SETTINGS_DIR="$HOME/Library/Application Support/Claude/Claude Extensions Settings"
+    SERVICE_CLAUDE_DIR="$HOME/.claude-bridge"
+    
+    if [ -d "$CLAUDE_EXTENSIONS_DIR" ]; then
+        mkdir -p "$SERVICE_CLAUDE_DIR"
+        cp -R "$CLAUDE_EXTENSIONS_DIR" "$SERVICE_CLAUDE_DIR/" 2>/dev/null || true
+        cp -R "$CLAUDE_EXTENSIONS_SETTINGS_DIR" "$SERVICE_CLAUDE_DIR/" 2>/dev/null || true
+        print_success "Claude Extensions copied for background service"
+    else
+        print_warning "No Claude Extensions found, MCP servers may not be available"
+    fi
+
+    print_success "✅ Service installed successfully!"
+    print_status "Next steps:"
+    print_status "  1. Run: ./manage-claude-bridge.sh start"
+    print_status "  2. Start WhatsApp bridge: docker-compose up -d"
+    print_status "  3. Test by sending yourself a WhatsApp message"
+}
+
+uninstall_service() {
+    print_status "Uninstalling Claude Bridge service..."
+    
+    # Stop service if running
+    stop_service
+    
+    # Remove plist file
+    if [ -f "$PLIST_FILE" ]; then
+        rm "$PLIST_FILE"
+        print_success "Service uninstalled"
+    else
+        print_warning "Service was not installed"
+    fi
+}
+
+start_service() {
+    print_status "Starting Claude Bridge service..."
+    
+    if [ ! -f "$PLIST_FILE" ]; then
+        print_error "Service not installed. Run './manage-claude-bridge.sh install' first"
+        return 1
+    fi
+    
+    launchctl load "$PLIST_FILE"
+    
+    if [ $? -eq 0 ]; then
+        print_success "Service started"
+        print_status "Service will start automatically on login"
+    else
+        print_error "Failed to start service"
+        return 1
+    fi
+}
+
+stop_service() {
+    print_status "Stopping Claude Bridge service..."
+    
+    launchctl unload "$PLIST_FILE" 2>/dev/null
+    
+    if [ $? -eq 0 ]; then
+        print_success "Service stopped"
+    else
+        print_warning "Service was not running"
+    fi
+}
+
+restart_service() {
+    print_status "Restarting Claude Bridge service..."
+    stop_service
+    sleep 2
+    start_service
+}
+
+status_service() {
+    print_status "Checking Claude Bridge service status..."
+    
+    # Check if virtual environment exists
+    if [ -d "$VENV_DIR" ] && [ -f "$VENV_PYTHON" ]; then
+        print_success "Virtual environment: OK ($VENV_DIR)"
+    else
+        print_warning "Virtual environment: MISSING ($VENV_DIR)"
+        print_status "Run './manage-claude-bridge.sh install' to fix this"
+        return 1
+    fi
+    
+    # Check if service is installed
+    if [ -f "$PLIST_FILE" ]; then
+        print_success "Service configuration: OK"
+    else
+        print_warning "Service configuration: MISSING"
+        print_status "Run './manage-claude-bridge.sh install' to fix this"
+        return 1
+    fi
+    
+    # Check if service is running
+    if launchctl list | grep -q "$SERVICE_NAME"; then
+        print_success "Service status: RUNNING"
+        
+        # Show recent log entries
+        print_status "Recent log entries:"
+        echo "===================="
+        tail -10 "$LOG_DIR/claude-bridge.log" 2>/dev/null || print_warning "No log file found yet"
+    else
+        print_warning "Service status: NOT RUNNING"
+        print_status "Run './manage-claude-bridge.sh start' to start the service"
+    fi
+}
+
+show_logs() {
+    print_status "Claude Bridge service logs:"
+    echo "============================="
+    
+    if [ -f "$LOG_DIR/claude-bridge.log" ]; then
+        tail -50 "$LOG_DIR/claude-bridge.log"
+    else
+        print_warning "No log file found"
+    fi
+    
+    echo
+    print_status "To follow logs in real-time, run:"
+    echo "tail -f '$LOG_DIR/claude-bridge.log'"
+}
+
+follow_logs() {
+    print_status "Following Claude Bridge service logs (Ctrl+C to stop):"
+    echo "======================================================"
+    
+    if [ -f "$LOG_DIR/claude-bridge.log" ]; then
+        tail -f "$LOG_DIR/claude-bridge.log"
+    else
+        print_warning "No log file found. Start the service first."
+    fi
+}
+
+show_help() {
+    echo "Claude Bridge Service Manager"
+    echo "============================="
+    echo
+    echo "Usage: $0 {install|uninstall|start|stop|restart|status|logs|follow|help}"
+    echo
+    echo "Commands:"
+    echo "  install     Install the background service"
+    echo "  uninstall   Remove the background service"
+    echo "  start       Start the service"
+    echo "  stop        Stop the service"
+    echo "  restart     Restart the service"
+    echo "  status      Check service status"
+    echo "  logs        Show recent logs"
+    echo "  follow      Follow logs in real-time"
+    echo "  help        Show this help message"
+    echo
+    echo "After installation, the service will start automatically when you log in."
+    echo "Send yourself a WhatsApp message to test the Claude integration!"
+}
+
+# Main script logic
+case "$1" in
+    install)
+        install_service
+        ;;
+    uninstall)
+        uninstall_service
+        ;;
+    start)
+        start_service
+        ;;
+    stop)
+        stop_service
+        ;;
+    restart)
+        restart_service
+        ;;
+    status)
+        status_service
+        ;;
+    logs)
+        show_logs
+        ;;
+    follow)
+        follow_logs
+        ;;
+    help|--help|-h)
+        show_help
+        ;;
+    *)
+        print_error "Unknown command: $1"
+        show_help
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
Add optional Claude Code Bridge service that enables users to interact with Claude Code through WhatsApp by messaging themselves. This allows remote access to Claude's capabilities via WhatsApp messages.

Key features:
- Background service runs as macOS launchd daemon
- Configurable tool permissions via ALLOWED_TOOLS environment variable
- Automatic message polling and response handling
- Full MCP server support through Claude Code CLI
- Auto-recovery on service crashes
- Chunked responses for long messages

The bridge is optional and doesn't affect the core WhatsApp MCP server functionality.

🤖 Generated with [Claude Code](https://claude.ai/code)